### PR TITLE
🐛 Always load node-fetch polyfill

### DIFF
--- a/src/cjs/fetch-polyfill.js
+++ b/src/cjs/fetch-polyfill.js
@@ -1,8 +1,6 @@
 const { default: fetch, Headers, Request, Response } = require("node-fetch");
 
-if (!globalThis.fetch) {
-  globalThis.fetch = fetch;
-  globalThis.Headers = Headers;
-  globalThis.Request = Request;
-  globalThis.Response = Response;
-}
+globalThis.fetch = fetch;
+globalThis.Headers = Headers;
+globalThis.Request = Request;
+globalThis.Response = Response;

--- a/src/esm/fetch-polyfill.js
+++ b/src/esm/fetch-polyfill.js
@@ -1,8 +1,6 @@
 import fetch, { Headers, Request, Response } from "node-fetch";
 
-if (!globalThis.fetch) {
-  globalThis.fetch = fetch;
-  globalThis.Headers = Headers;
-  globalThis.Request = Request;
-  globalThis.Response = Response;
-}
+globalThis.fetch = fetch;
+globalThis.Headers = Headers;
+globalThis.Request = Request;
+globalThis.Response = Response;

--- a/src/ts/fetch-polyfill.ts
+++ b/src/ts/fetch-polyfill.ts
@@ -1,9 +1,7 @@
 // @ts-nocheck
 import fetch, { Headers, Request, Response } from "node-fetch";
 
-if (!globalThis.fetch) {
-  globalThis.fetch = fetch as any;
-  globalThis.Headers = Headers as any;
-  globalThis.Request = Request as any;
-  globalThis.Response = Response as any;
-}
+globalThis.fetch = fetch as any;
+globalThis.Headers = Headers as any;
+globalThis.Request = Request as any;
+globalThis.Response = Response as any;


### PR DESCRIPTION
Due to an issue in Node.js 18.1.0 with fetch implementation of undici, the request content-type was invalid. See https://github.com/nodejs/undici/pull/1401
This change makes sure to always use stable node-fetch.