### PR TITLE
🐛 only inline environment variables where absolutely necessary

### DIFF
--- a/babel.config.mjs
+++ b/babel.config.mjs
@@ -3,6 +3,6 @@ dotenv.config();
 
 const config = {
   presets: ["@babel/preset-typescript"],
-  plugins: ['transform-inline-environment-variables'],
+  plugins: [['transform-inline-environment-variables', {include: ['npm_package_version']}]],
 };
 export default config;

--- a/webpack.config.mjs
+++ b/webpack.config.mjs
@@ -9,7 +9,7 @@ const { API_HOST, npm_package_version } = process.env;
 console.debug("env:", { API_HOST, npm_package_version });
 
 const plugins = [
-  new webpack.EnvironmentPlugin(["API_HOST", "npm_package_version"]),
+  new webpack.EnvironmentPlugin(["API_HOST"]),
 ];
 
 /** @type import('webpack').Configuration */


### PR DESCRIPTION
So that we don't accidentally inline ones missing at build time as `undefined`
